### PR TITLE
loader: only load .ftl files as fluent files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ fluent-bundle = "0.6.0"
 fluent-syntax = "0.9.0"
 fluent-locale = "0.4.1"
 serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3.1.0"


### PR DESCRIPTION
While I was working on the localization of Rust website, the application
kept panicking at startup, because VIM creates temporary files inside
the directory containing the FTL files, and those temporary files are
not valid UTF-8.

This commit changes the localization code to only load .ftl files from
the locales directory, preventing such issues from happening again.

r? @Manishearth 