### PR TITLE
Tera support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
   - linux
 
 script:
-  - cargo build
-  - cargo test
-
+  - cargo build && cargo build --all-features
+  - cargo test && cargo test --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,19 @@ keywords = ["handlebars", "fluent", "internationalization", "localization"]
 categories = ["internationalization", "localization", "template-engine"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
-handlebars = "2"
+handlebars = { version = "2", optional = true }
 lazy_static = "1.2.0"
 fluent = "0.5"
 fluent-bundle = "0.6.0"
 fluent-syntax = "0.9.0"
 fluent-locale = "0.4.1"
 serde_json = "1.0"
+tera = { version = "1.0.2", optional = true }
+snafu = "0.6.2"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "handlebars-fluent"
+name = "fluent-template-helper"
 version = "0.2.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 description = "Handlebars helpers for the Fluent internationalization framework"
 license = "MIT/Apache-2.0"
-documentation = "https://docs.rs/handlebars-fluent/"
-repository = "https://github.com/manishearth/handlebars-fluent"
+documentation = "https://docs.rs/fluent-template-helper/"
+repository = "https://github.com/manishearth/fluent-template-helper"
 keywords = ["handlebars", "fluent", "internationalization", "localization"]
 categories = ["internationalization", "localization", "template-engine"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "fluent-template-helper"
 version = "0.2.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
-description = "Handlebars helpers for the Fluent internationalization framework"
+description = "Template engine helpers for the Fluent internationalization framework"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/fluent-template-helper/"
 repository = "https://github.com/manishearth/fluent-template-helper"
-keywords = ["handlebars", "fluent", "internationalization", "localization"]
+keywords = ["handlebars", "fluent", "internationalization", "localization", "tera"]
 categories = ["internationalization", "localization", "template-engine"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,132 +1,17 @@
-use handlebars::{
-    Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext, RenderError,
-    Renderable,
-};
+#[cfg(feature = "handlebars")]
+mod handlebars;
+#[cfg(feature = "tera")]
+mod tera;
 
-use fluent_bundle::FluentValue;
-use handlebars::template::{Parameter, TemplateElement};
-use serde_json::Value as Json;
-use std::collections::HashMap;
-use std::io;
-
-use crate::Loader;
-
-pub struct FluentHelper<L> {
+/// The helper type that implements `handlebars::HelperDef` with the
+/// `handlebars` feature and `tera::Function` with the `tera` feature.
+#[allow(dead_code)]
+pub struct FluentHelperFunction<L> {
     loader: L,
 }
 
-impl<L> FluentHelper<L> {
+impl<L> FluentHelperFunction<L> {
     pub fn new(loader: L) -> Self {
         Self { loader }
-    }
-}
-
-#[derive(Default)]
-struct StringOutput {
-    pub s: String,
-}
-
-impl Output for StringOutput {
-    fn write(&mut self, seg: &str) -> Result<(), io::Error> {
-        self.s.push_str(seg);
-        Ok(())
-    }
-}
-
-impl<L: Loader + Send + Sync> HelperDef for FluentHelper<L> {
-    fn call<'reg: 'rc, 'rc>(
-        &self,
-        h: &Helper<'reg, 'rc>,
-        reg: &'reg Handlebars,
-        context: &'rc Context,
-        rcx: &mut RenderContext<'reg>,
-        out: &mut dyn Output,
-    ) -> HelperResult {
-        let id = if let Some(id) = h.param(0) {
-            id
-        } else {
-            return Err(RenderError::new(
-                "{{fluent}} must have at least one parameter",
-            ));
-        };
-
-        if id.path().is_some() {
-            return Err(RenderError::new(
-                "{{fluent}} takes a string parameter with no path",
-            ));
-        }
-
-        let id = if let Json::String(ref s) = *id.value() {
-            s
-        } else {
-            return Err(RenderError::new("{{fluent}} takes a string parameter"));
-        };
-
-        let mut args = if h.hash().is_empty() {
-            None
-        } else {
-            let map = h
-                .hash()
-                .iter()
-                .filter_map(|(k, v)| {
-                    let json = v.value();
-                    let val = match *json {
-                        Json::Number(ref n) => FluentValue::Number(n.to_string()),
-                        Json::String(ref s) => FluentValue::String(s.to_string()),
-                        _ => return None,
-                    };
-                    Some((&**k, val))
-                })
-                .collect();
-            Some(map)
-        };
-
-        if let Some(tpl) = h.template() {
-            if args.is_none() {
-                args = Some(HashMap::new());
-            }
-            let args = args.as_mut().unwrap();
-            for element in &tpl.elements {
-                if let TemplateElement::HelperBlock(ref block) = element {
-                    if block.name != Parameter::Name("fluentparam".into()) {
-                        return Err(RenderError::new(format!(
-                            "{{{{fluent}}}} can only contain {{{{fluentparam}}}} elements, not {}",
-                            block.name.expand_as_name(reg, context, rcx).unwrap()
-                        )));
-                    }
-                    let id = if let Some(el) = block.params.get(0) {
-                        if let Parameter::Literal(ref s) = *el {
-                            if let Json::String(ref s) = *s {
-                                s
-                            } else {
-                                return Err(RenderError::new(
-                                    "{{fluentparam}} takes a string parameter",
-                                ));
-                            }
-                        } else {
-                            return Err(RenderError::new(
-                                "{{fluentparam}} takes a string parameter",
-                            ));
-                        }
-                    } else {
-                        return Err(RenderError::new("{{fluentparam}} must have one parameter"));
-                    };
-                    if let Some(ref tpl) = block.template {
-                        let mut s = StringOutput::default();
-                        tpl.render(reg, context, rcx, &mut s)?;
-                        args.insert(&*id, FluentValue::String(s.s.into()));
-                    }
-                }
-            }
-        }
-        let lang = context
-            .data()
-            .get("lang")
-            .expect("Language not set in context")
-            .as_str()
-            .expect("Language must be string");
-
-        let response = self.loader.lookup(lang, &id, args.as_ref());
-        out.write(&response).map_err(RenderError::with)
     }
 }

--- a/src/helper/handlebars.rs
+++ b/src/helper/handlebars.rs
@@ -1,0 +1,123 @@
+use handlebars::{
+    Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext, RenderError,
+    Renderable,
+};
+
+use fluent_bundle::FluentValue;
+use handlebars::template::{Parameter, TemplateElement};
+use serde_json::Value as Json;
+use std::collections::HashMap;
+use std::io;
+
+use super::FluentHelperFunction;
+use crate::Loader;
+
+#[derive(Default)]
+struct StringOutput {
+    pub s: String,
+}
+
+impl Output for StringOutput {
+    fn write(&mut self, seg: &str) -> Result<(), io::Error> {
+        self.s.push_str(seg);
+        Ok(())
+    }
+}
+
+impl<L: Loader + Send + Sync> HelperDef for FluentHelperFunction<L> {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        reg: &'reg Handlebars,
+        context: &'rc Context,
+        rcx: &mut RenderContext<'reg>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let id = if let Some(id) = h.param(0) {
+            id
+        } else {
+            return Err(RenderError::new(
+                "{{fluent}} must have at least one parameter",
+            ));
+        };
+
+        if id.path().is_some() {
+            return Err(RenderError::new(
+                "{{fluent}} takes a string parameter with no path",
+            ));
+        }
+
+        let id = if let Json::String(ref s) = *id.value() {
+            s
+        } else {
+            return Err(RenderError::new("{{fluent}} takes a string parameter"));
+        };
+
+        let mut args = if h.hash().is_empty() {
+            None
+        } else {
+            let map = h
+                .hash()
+                .iter()
+                .filter_map(|(k, v)| {
+                    let json = v.value();
+                    let val = match *json {
+                        Json::Number(ref n) => FluentValue::Number(n.to_string()),
+                        Json::String(ref s) => FluentValue::String(s.to_string()),
+                        _ => return None,
+                    };
+                    Some((&**k, val))
+                })
+                .collect();
+            Some(map)
+        };
+
+        if let Some(tpl) = h.template() {
+            if args.is_none() {
+                args = Some(HashMap::new());
+            }
+            let args = args.as_mut().unwrap();
+            for element in &tpl.elements {
+                if let TemplateElement::HelperBlock(ref block) = element {
+                    if block.name != Parameter::Name("fluentparam".into()) {
+                        return Err(RenderError::new(format!(
+                            "{{{{fluent}}}} can only contain {{{{fluentparam}}}} elements, not {}",
+                            block.name.expand_as_name(reg, context, rcx).unwrap()
+                        )));
+                    }
+                    let id = if let Some(el) = block.params.get(0) {
+                        if let Parameter::Literal(ref s) = *el {
+                            if let Json::String(ref s) = *s {
+                                s
+                            } else {
+                                return Err(RenderError::new(
+                                    "{{fluentparam}} takes a string parameter",
+                                ));
+                            }
+                        } else {
+                            return Err(RenderError::new(
+                                "{{fluentparam}} takes a string parameter",
+                            ));
+                        }
+                    } else {
+                        return Err(RenderError::new("{{fluentparam}} must have one parameter"));
+                    };
+                    if let Some(ref tpl) = block.template {
+                        let mut s = StringOutput::default();
+                        tpl.render(reg, context, rcx, &mut s)?;
+                        args.insert(&*id, FluentValue::String(s.s.into()));
+                    }
+                }
+            }
+        }
+        let lang = context
+            .data()
+            .get("lang")
+            .expect("Language not set in context")
+            .as_str()
+            .expect("Language must be string");
+
+        let response = self.loader.lookup(lang, &id, args.as_ref());
+        out.write(&response).map_err(RenderError::with)
+    }
+}

--- a/src/helper/tera.rs
+++ b/src/helper/tera.rs
@@ -1,0 +1,60 @@
+use fluent_bundle::FluentValue;
+use serde_json::Value as Json;
+use snafu::OptionExt;
+use std::collections::HashMap;
+
+use super::FluentHelperFunction;
+use crate::Loader;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+const LANG_KEY: &str = "_lang";
+const FLUENT_KEY: &str = "_id";
+
+#[derive(Debug, snafu::Snafu)]
+enum Error {
+    #[snafu(display("No `lang` argument provided."))]
+    NoLangArgument,
+    #[snafu(display("No `_id` argument provided."))]
+    NoFluentArgument,
+    #[snafu(display("Couldn't convert JSON to Fluent value."))]
+    JsonToFluentFail,
+}
+
+impl From<Error> for tera::Error {
+    fn from(error: Error) -> Self {
+        tera::Error::msg(error)
+    }
+}
+
+fn json_to_fluent(json: Json) -> Result<FluentValue> {
+    match json {
+        Json::Number(ref n) => Ok(FluentValue::Number(n.to_string())),
+        Json::String(ref s) => Ok(FluentValue::String(s.to_string())),
+        _ => Err(Error::JsonToFluentFail),
+    }
+}
+
+impl<L: Loader + Send + Sync> tera::Function for FluentHelperFunction<L> {
+    fn call(&self, args: &HashMap<String, Json>) -> Result<Json, tera::Error> {
+        let lang = args
+            .get(LANG_KEY)
+            .and_then(Json::as_str)
+            .context(self::NoLangArgument)?;
+        let id = args
+            .get(FLUENT_KEY)
+            .and_then(Json::as_str)
+            .context(self::NoFluentArgument)?;
+        let fluent_values = args
+            .values()
+            .cloned()
+            .map(json_to_fluent)
+            .collect::<Result<Vec<_>>>()?;
+
+        let fluent_args = args.keys().map(String::as_str).zip(fluent_values).collect();
+
+        let response = self.loader.lookup(lang, &id, Some(&fluent_args));
+
+        Ok(Json::String(response))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,49 +1,86 @@
-//! [Fluent](https://projectfluent.org/) helper for [Handlebars](https://docs.rs/handlebars).
+//! [Fluent](https://projectfluent.org/) functions for templating engines.
 //!
-//! This crate provides a Handlebars helper that can load Fluent strings.
+//! This crate provides a way to load Fluent strings from different
+//! templating engines.
+//! # Current Supported Template Engines
+//! - [Handlebars](https://docs.rs/handlebars).
+//! - [Tera](https://docs.rs/tera).
 //!
+//! # Set up
+//! The first thing you need is a `Loader` to load and  render fluent templates.
+//! The easiest way to do this currently is to use the [`simple_loader!()`]
+//! macro. Then you need to define the `fluent` function with your templating
+//! engine.  This is will vary slightly depending on your templating engine.
 //!
-//! # Setting up the fluent helper with handlebars
-//!
-//! The easiest way to use this is to use the [`simple_loader!()`] macro:
+//! ## Handlebars
 //!
 //! ```rust
-//! use handlebars_fluent::*;
-//! use handlebars::*;
-//! use serde_json::*;
+//! # #[cfg(feature = "handlebars")] {
+//! use handlebars_fluent::FluentHelperFunction;
 //!
-//! simple_loader!(create_loader, "./locales/", "en-US");
+//! handlebars_fluent::simple_loader!(create_loader, "./locales/", "en-US");
 //!
-//! fn init(handlebars: &mut Handlebars) {
+//! fn init(engine: &mut handlebars::Handlebars) {
+//!     // Pick your engine
 //!     let loader = create_loader();
-//!     let helper = FluentHelper::new(loader);
-//!     handlebars.register_helper("fluent", Box::new(helper));
+//!     let helper = FluentHelperFunction::new(loader);
+//!
+//!     // TODO: Delete one of these lines
+//!     // Handlebars
+//!     engine.register_helper("fluent", Box::new(helper));
 //! }
 //!
-//! fn render_page(handlebars: &Handlebars) -> String {
-//!     let data = json!({"lang": "zh-CN"});
-//!     handlebars.render_template("{{fluent \"foo-bar\"}} baz", &data).unwrap()
+//! fn render_page(engine: &handlebars::Handlebars) -> String {
+//!     let data = serde_json::json!({"lang": "zh-CN"});
+//!     // TODO: Delete one of these lines
+//!     // Handlebars
+//!     engine.render_template("{{fluent \"foo-bar\"}} baz", &data).unwrap()
 //! }
+//! # }
+//! ```
+//!
+//! ## Tera
+//!
+//! ```rust
+//! # #[cfg(feature = "tera")] {
+//! use handlebars_fluent::FluentHelperFunction;
+//!
+//! handlebars_fluent::simple_loader!(create_loader, "./locales/", "en-US");
+//!
+//! fn init(engine: &mut tera::Tera) {
+//!     // Pick your engine
+//!     let loader = create_loader();
+//!     let helper = FluentHelperFunction::new(loader);
+//!
+//!     engine.register_function("fluent", helper);
+//!     engine.add_raw_template("foo", "{{fluent \"foo-bar\"}} baz").unwrap();
+//! }
+//!
+//! fn render_page(engine: &tera::Tera) -> String {
+//!     let data = serde_json::json!({"lang": "zh-CN"});
+//!     let context = tera::Context::from_value(data).unwrap();
+//!     engine.render("foo", &context).unwrap()
+//! }
+//! # }
 //! ```
 //!
 //! You should have a `locales/` folder somewhere with one folder per language code,
 //! containing all of your FTL files. See the [`simple_loader!()`] macro for more options.
 //!
+//! # Handlebars Syntax
+//!
 //! Make sure the [`handlebars::Context`] has a toplevel "lang" field when rendering.
-//!
-//!
-//! # Using the fluent helper in your templates
 //!
 //! The main helper provided is the `{{fluent}}` helper. If you have the following Fluent
 //! file:
-//! 
+//!
 //! ```fluent
 //! foo-bar = "foo bar"
 //! placeholder = this has a placeholder { $variable }
 //! ```
 //!
 //! You can include the strings in your template with
-//! 
+//!
 //! ```hbs
 //! {{fluent "foo-bar"}} <!-- will render "foo bar" -->
 //! {{fluent "placeholder" variable="baz"}} <!-- will render "this has a placeholder baz" -->
@@ -65,8 +102,32 @@
 //!
 //! [variables]: https://projectfluent.org/fluent/guide/variables.html
 //! [`simple_loader!()`]: ./macro.simple_loader.html
-
-
+//!
+//! # Tera Syntax
+//! For `Tera` we provide a `tera::Function` implementation. You need provide
+//! both a `_id` pointing to the fluent property and `_lang` pointing to a
+//! language code. Any extra parameters will be sent as variables to fluent.
+//!
+//! ## Basic
+//! ```tera
+//! {{ fluent(_fluent_key="foo-bar", _lang="en-US") }}
+//! ```
+//!
+//! ## With parameters
+//! ```tera
+//! {{ fluent(_fluent_key="foo-bar", _lang="en-US", param="value") }}
+//! ```
+//!
+//! Instead of `fluentparam` in handlebars you can [manipulate data][mand]
+//! directly with Tera templates.
+//!
+//! ```tera
+//! {% set link = '<a href="' ~ url ~ '">' ~ url_text ~ '</a>' %}
+//! {{ fluent(_fluent_key="foo-bar", _lang="en-US", param=link) }}
+//! ```
+//!
+//! [mand]: https://tera.netlify.com/docs/#manipulating-data
+//!
 
 #[doc(hidden)]
 pub extern crate lazy_static;
@@ -74,7 +135,7 @@ pub extern crate lazy_static;
 #[doc(hidden)]
 pub extern crate fluent_bundle;
 
-pub use helper::FluentHelper;
+pub use helper::FluentHelperFunction;
 pub use loader::{Loader, SimpleLoader};
 
 mod helper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "handlebars")] {
-//! use handlebars_fluent::FluentHelperFunction;
+//! use fluent_template_helper::FluentHelperFunction;
 //!
-//! handlebars_fluent::simple_loader!(create_loader, "./locales/", "en-US");
+//! fluent_template_helper::simple_loader!(create_loader, "./locales/", "en-US");
 //!
 //! fn init(engine: &mut handlebars::Handlebars) {
 //!     // Pick your engine
@@ -43,9 +43,9 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "tera")] {
-//! use handlebars_fluent::FluentHelperFunction;
+//! use fluent_template_helper::FluentHelperFunction;
 //!
-//! handlebars_fluent::simple_loader!(create_loader, "./locales/", "en-US");
+//! fluent_template_helper::simple_loader!(create_loader, "./locales/", "en-US");
 //!
 //! fn init(engine: &mut tera::Tera) {
 //!     // Pick your engine

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -219,12 +219,12 @@ fn read_from_dir<P: AsRef<Path>>(dirname: P) -> io::Result<Vec<FluentResource>> 
     Ok(result)
 }
 
-pub fn create_bundle(
+pub fn create_bundle<'a>(
     lang: &str,
-    resources: &'static Vec<FluentResource>,
-    core_resource: Option<&'static FluentResource>,
-    customizer: &impl Fn(&mut FluentBundle<'static>),
-) -> FluentBundle<'static> {
+    resources: &'a Vec<FluentResource>,
+    core_resource: Option<&'a FluentResource>,
+    customizer: &impl Fn(&mut FluentBundle),
+) -> FluentBundle<'a> {
     let mut bundle = FluentBundle::new(&[lang]);
     if let Some(core) = core_resource {
         bundle
@@ -256,11 +256,11 @@ pub fn build_resources(dir: &str) -> HashMap<String, Vec<FluentResource>> {
     all_resources
 }
 
-pub fn build_bundles(
-    resources: &'static HashMap<String, Vec<FluentResource>>,
-    core_resource: Option<&'static FluentResource>,
-    customizer: impl Fn(&mut FluentBundle<'static>),
-) -> HashMap<String, FluentBundle<'static>> {
+pub fn build_bundles<'a>(
+    resources: &'a HashMap<String, Vec<FluentResource>>,
+    core_resource: Option<&'a FluentResource>,
+    customizer: impl Fn(&mut FluentBundle),
+) -> HashMap<String, FluentBundle<'a>> {
     let mut bundles = HashMap::new();
     for (ref k, ref v) in &*resources {
         bundles.insert(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -31,7 +31,7 @@ pub trait Loader {
 ///
 /// fn init() {
 ///     let loader = create_loader();
-///     let helper = FluentHelper::new(loader);
+///     let helper = FluentHelperFunction::new(loader);
 /// }
 /// ```
 ///
@@ -41,7 +41,7 @@ pub trait Loader {
 ///
 /// Some Fluent users have a share "core.ftl" file that contains strings used by all locales,
 /// for example branding information. They also may want to define custom functions on the bundle.
-/// 
+///
 /// This can be done with an extended invocation:
 ///
 /// ```rust
@@ -52,7 +52,7 @@ pub trait Loader {
 ///
 /// fn init() {
 ///     let loader = create_loader();
-///     let helper = FluentHelper::new(loader);
+///     let helper = FluentHelperFunction::new(loader);
 /// }
 /// ```
 ///

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -25,7 +25,7 @@ pub trait Loader {
 /// Usage:
 ///
 /// ```rust
-/// use handlebars_fluent::*;
+/// use fluent_template_helper::*;
 ///
 /// simple_loader!(create_loader, "./tests/locales/", "en-US");
 ///
@@ -45,7 +45,7 @@ pub trait Loader {
 /// This can be done with an extended invocation:
 ///
 /// ```rust
-/// use handlebars_fluent::*;
+/// use fluent_template_helper::*;
 ///
 /// simple_loader!(create_loader, "./tests/locales/", "en-US", core: "./tests/core.ftl",
 ///                customizer: |bundle| {bundle.add_function("FOOBAR", |_values, _named| {unimplemented!()}); });

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -221,7 +221,7 @@ fn read_from_dir<P: AsRef<Path>>(dirname: P) -> io::Result<Vec<FluentResource>> 
 
 pub fn create_bundle<'a>(
     lang: &str,
-    resources: &'a Vec<FluentResource>,
+    resources: &'a [FluentResource],
     core_resource: Option<&'a FluentResource>,
     customizer: &impl Fn(&mut FluentBundle),
 ) -> FluentBundle<'a> {

--- a/tests/handlebars.rs
+++ b/tests/handlebars.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "handlebars")]
+
 use handlebars::*;
 use handlebars_fluent::*;
 
@@ -8,7 +10,7 @@ use serde_json::json;
 #[test]
 fn test_english() {
     let mut handlebars = Handlebars::new();
-    handlebars.register_helper("fluent", Box::new(FluentHelper::new(load())));
+    handlebars.register_helper("fluent", Box::new(FluentHelperFunction::new(load())));
     let data = json!({"lang": "en-US"});
     assert_eq!(
         handlebars
@@ -53,7 +55,7 @@ fn test_english() {
 #[test]
 fn test_french() {
     let mut handlebars = Handlebars::new();
-    handlebars.register_helper("fluent", Box::new(FluentHelper::new(load())));
+    handlebars.register_helper("fluent", Box::new(FluentHelperFunction::new(load())));
     let data = json!({"lang": "fr"});
     assert_eq!(
         handlebars
@@ -98,7 +100,7 @@ fn test_french() {
 #[test]
 fn test_chinese() {
     let mut handlebars = Handlebars::new();
-    handlebars.register_helper("fluent", Box::new(FluentHelper::new(load())));
+    handlebars.register_helper("fluent", Box::new(FluentHelperFunction::new(load())));
     let data = json!({"lang": "zh-TW"});
     assert_eq!(
         handlebars

--- a/tests/handlebars.rs
+++ b/tests/handlebars.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "handlebars")]
 
 use handlebars::*;
-use handlebars_fluent::*;
+use fluent_template_helper::*;
 
 simple_loader!(load, "./tests/locales", "en-US", core: "./tests/locales/core.ftl", customizer: |_bundle| {});
 

--- a/tests/tera.rs
+++ b/tests/tera.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "tera")]
+
+use handlebars_fluent::*;
+use tera::*;
+
+simple_loader!(load, "./tests/locales", "en-US", core: "./tests/locales/core.ftl", customizer: |_bundle| {});
+
+macro_rules! assert_templates {
+    ($($test:ident ( $lang:expr ) => { $($content:expr => $assert:expr),+ }),+) => {
+        $(
+            #[test]
+            fn $test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+                let ctx = Context::from_value(serde_json::json!({ "lang": $lang }))?;
+                let mut tera = Tera::default();
+                tera.register_function("fluent", FluentHelperFunction::new(load()));
+                $(
+                    tera.add_raw_template("_tmp.html", $content)?;
+                    let render = tera.render("_tmp.html", &ctx)?;
+
+                    assert_eq!($assert, render);
+                )+
+                    Ok(())
+            }
+        )+
+    };
+}
+
+assert_templates! {
+    english("en-US") => {
+        r#"{{ fluent(_id="simple", _lang=lang) }}"# => "simple text",
+        r#"{{ fluent(_id="reference", _lang=lang) }}"# => "simple text with a reference: foo",
+        r#"{{ fluent(_id="parameter", _lang=lang, param="PARAM") }}"# => "text with a PARAM",
+        r#"{{ fluent(_id="parameter2", _lang=lang, param1="P1", param2="P2") }}"# => "text one P1 second P2",
+        r#"{{ fluent(_id="fallback", _lang=lang) }}"# => "this should fall back"
+    },
+    french("fr") => {
+        r#"{{ fluent(_id="simple", _lang=lang) }}"# => "texte simple",
+        r#"{{ fluent(_id="reference", _lang=lang) }}"# => "texte simple avec une référence: foo",
+        r#"{{ fluent(_id="parameter", _lang=lang, param="PARAM") }}"# => "texte avec une PARAM",
+        r#"{{ fluent(_id="parameter2", _lang=lang, param1="P1", param2="P2") }}"# => "texte une P1 seconde P2",
+        r#"{{ fluent(_id="fallback", _lang=lang) }}"# => "this should fall back"
+    },
+    chinese("zh-TW") => {
+        r#"{{ fluent(_id="exists", _lang=lang) }}"# => "兒",
+        r#"{{ fluent(_id="fallback-zh", _lang=lang) }}"# => "气",
+        r#"{{ fluent(_id="fallback", _lang=lang) }}"# => "this should fall back"
+    }
+}

--- a/tests/tera.rs
+++ b/tests/tera.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "tera")]
 
-use handlebars_fluent::*;
+use fluent_template_helper::*;
 use tera::*;
 
 simple_loader!(load, "./tests/locales", "en-US", core: "./tests/locales/core.ftl", customizer: |_bundle| {});


### PR DESCRIPTION
This PR adds support for the [Tera] templating engine. I've also included a potential name change since it's no longer exclusively for handlebars, I'm not too particular on the name though, hence why it's a seperate commit.

### Syntax

Currently we require 2 parameters, the fluent property id, and the language code.
```jinja
{% fluent(_id="foo-bar", _lang="en-US") %}
```

Any extra params will be sent to fluent.
```jinja
{% fluent(_id="foo-bar", _lang="en-US", param="value") %}
```

[tera]: https://tera.netlify.com