### PR TITLE
Update handlebars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["internationalization", "localization", "template-engine"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-handlebars = "2.0"
+handlebars = "4.0"
 lazy_static = "1.4"
 fluent = "0.16"
 fluent-bundle = "0.11"

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -39,7 +39,7 @@ impl<L: Loader + Send + Sync> HelperDef for FluentHelper<L> {
         h: &Helper<'reg, 'rc>,
         reg: &'reg Handlebars,
         context: &'rc Context,
-        rcx: &mut RenderContext<'reg>,
+        rcx: &mut RenderContext<'reg, 'rc>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let id = if let Some(id) = h.param(0) {
@@ -50,7 +50,7 @@ impl<L: Loader + Send + Sync> HelperDef for FluentHelper<L> {
             ));
         };
 
-        if id.path().is_some() {
+        if id.relative_path().is_some() {
             return Err(RenderError::new(
                 "{{fluent}} takes a string parameter with no path",
             ));
@@ -126,6 +126,7 @@ impl<L: Loader + Send + Sync> HelperDef for FluentHelper<L> {
             .expect("Language not valid identifier");
 
         let response = self.loader.lookup(&lang, id, args.as_ref());
-        out.write(&response).map_err(RenderError::with)
+        out.write(&response)
+            .map_err(|e| RenderError::from_error("failed to write response", e))
     }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -148,7 +148,7 @@ impl SimpleLoader {
             if let Some(message) = bundle.get_message(text_id).and_then(|m| m.value) {
                 let mut errors = Vec::new();
 
-                let value = bundle.format_pattern(message, dbg!(args), &mut errors);
+                let value = bundle.format_pattern(message, args, &mut errors);
 
                 if errors.is_empty() {
                     Some(value.into())


### PR DESCRIPTION
closes #10 

The changelog of `handlebars` doesn't mention the rename from `path` to `relative_path`, but I found [this diff](https://github.com/sunng87/handlebars-rust/commit/69f3252ab66abaecfeb1371fb164e3d30dd5f30d#diff-be1c878c753064b7eaddf4a10ba4215a93dd1817d31e6788691cdb29752fd612R89) which indicates it was a pure refactor.