### PR TITLE
Update Handlebars to 6.x and Fluent crates to current

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[resolver]
+incompatible-rust-versions = "fallback"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["internationalization", "localization", "template-engine"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-handlebars = "5.0"
-lazy_static = "1.4"
+handlebars = "6.3"
+lazy_static = "1.5"
 fluent = "0.16"
 fluent-bundle = "0.16"
 fluent-syntax = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["internationalization", "localization", "template-engine"]
 handlebars = "5.0"
 lazy_static = "1.4"
 fluent = "0.16"
-fluent-bundle = "0.11"
-fluent-syntax = "0.11"
-fluent-langneg = "0.12"
+fluent-bundle = "0.16"
+fluent-syntax = "0.12"
+fluent-langneg = "0.13"
 serde_json = "1.0"
-unic-langid = { version = "0.8", features = ["macros"] }
+unic-langid = { version = "0.9", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "handlebars-fluent"
 version = "0.3.2"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
+rust-version = "1.73.0"
 description = "Handlebars helpers for the Fluent internationalization framework"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/handlebars-fluent/"


### PR DESCRIPTION
- **deps: Bump Fluent crates to latest minor releases**
- **refactor: Adjust Fluent API usage for current upstream crate versions**
- **chore: Use MSRV aware resolver for Rust dependencies**
- **deps: Bump Handlebars to current**
- **chore: Document current MSRV (bounded by handlebars 6.3's MSRV)**
