### PR TITLE
Trigger release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handlebars-fluent"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 description = "Handlebars helpers for the Fluent internationalization framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handlebars-fluent"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 rust-version = "1.73.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## handlebars-fluent
 
-[![Build Status](https://travis-ci.org/Manishearth/handlebars-fluent.svg?branch=master)](https://travis-ci.org/Manishearth/handlebars-fluent)
+[![Build Status](https://github.com/Manishearth/handlebars-fluent/workflows/Rust/badge.svg)](https://github.com/Manishearth/handlebars-fluent/actions)
 [![Current Version](https://img.shields.io/crates/v/handlebars-fluent)](https://crates.io/crates/handlebars-fluent)
 [![License: MIT/Apache-2.0](https://img.shields.io/crates/l/handlebars-fluent.svg)](#license)
 


### PR DESCRIPTION
Closes #17

I don't think there is much to be done for the release. BEFORE this gets merged however I would look into what happened with 0.4.0. It is [released on craties.io](https://crates.io/crates/handlebars-fluent/0.4.0) and the [docs.rs site meta data](https://docs.rs/crate/handlebars-fluent/0.4.0/source/.cargo_vcs_info.json) identifies 329db2809e9eba712faa37c6d9097f6ee3286a10 as the commit it was publish from. But I don't see that commit in this repository. I would first find and merge whatever local branch you must have published that from so that the topology makes some sense, **then** merge this one and tag it as v0.5.0. It could also be v0.4.1 because there are no related semver requirements, but with the major change in handlebars version being pulled in that will come with different feature expectations, so a minor version release makes more sense to me.

```console
$ git describe --tags --always
v0.3.1-14-g1ca8984

$ cargo semver-checks --baseline-rev v0.3.1 --release-type minor --all-features
     Cloning v0.3.1
    Building handlebars-fluent v0.5.0 (current)
       Built [   0.439s] (current)
     Parsing handlebars-fluent v0.5.0 (current)
      Parsed [   0.002s] (current)
    Building handlebars-fluent v0.3.1 (baseline)
       Built [   0.412s] (baseline)
     Parsing handlebars-fluent v0.3.1 (baseline)
      Parsed [   0.003s] (baseline)
    Checking handlebars-fluent v0.3.1 -> v0.5.0 (assume minor change)
     Checked [   0.004s] 128 checks: 128 pass, 36 skip
     Summary no semver update required
    Finished [   3.360s] handlebars-fluent
```
