### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handlebars-fluent"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 rust-version = "1.73.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ categories = ["internationalization", "localization", "template-engine"]
 [dependencies]
 handlebars = "6.3"
 lazy_static = "1.5"
-fluent = "0.16"
 fluent-bundle = "0.16"
-fluent-syntax = "0.12"
 fluent-langneg = "0.13"
 serde_json = "1.0"
 unic-langid = { version = "0.9", features = ["macros"] }


### PR DESCRIPTION
We had [a bit of a snafu upstream](https://github.com/projectfluent/fluent-rs/issues/384) because we broke semver in fluent but gave it a patch version. We yanked 0.16.2 and republished it as 0.17.0. That in itself didn't break this project, but in *reviewing* what it did effect I realized you have a direct dependency on `fluent`, but are only actually using the lower level APIs provided by `fluent-bundle` directly. This means a secondary set of dependencies with two versions of `fluent-syntax` was getting pulled in even though it wasn't used. This is a relatively minor fix, but it does clean up the dependency graph quite a bit and keep unused conflicting versions out of the mix.
